### PR TITLE
Remove showing of the token to prevent security issues

### DIFF
--- a/Src/PowerShell/github-calls.ps1
+++ b/Src/PowerShell/github-calls.ps1
@@ -324,7 +324,6 @@ function GetRawFile {
         return ""
     }
 
-    Write-Host "GetRawFile: $url"
     if ($null -eq $url) {
         Write-Warning "Cannot handle empty url"
         return ""


### PR DESCRIPTION
### What are the incoming changes?
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6c7243b</samp>

Removed unnecessary logging from `github-calls.ps1`. This improves the readability of the output and reduces noise.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 6c7243b</samp>

> _`Write-Host` gone now_
> _Invoke-RestMethod logs `url`_
> _Autumn leaves no trace_

### Why are they needed
<!-- author to complete, pleas include a link to the issue number -->

### How has this been achieved?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6c7243b</samp>

*  Removed debug output from `Write-Host` statement ([link](https://github.com/devops-actions/load-used-actions/pull/70/files?diff=unified&w=0#diff-ec4505bba40c8b349d9df2088ed07cefac1546a23171c8e1d12e8f2238e8d9d3L327)) in `Src/PowerShell/github-calls.ps1`
