### PR TITLE
Include versions ref in report

### DIFF
--- a/Src/PowerShell/load-used-actions.ps1
+++ b/Src/PowerShell/load-used-actions.ps1
@@ -114,7 +114,7 @@ function GetAllUsedActionsFromRepo {
         return;
     }
     
-    # create hastable to store the results in
+    # create hashtable to store the results in
     $actionsInRepo = @()
 
     Write-Host "Found [$($workflowFiles.Length)] files in the workflows directory"

--- a/Src/PowerShell/load-used-actions.ps1
+++ b/Src/PowerShell/load-used-actions.ps1
@@ -159,6 +159,7 @@ function SummarizeActionsUsed {
             $newInfo =  [PSCustomObject]@{
                 repo = $action.repo
                 workflowFileName = $action.workflowFileName
+                actionRef = $action.actionRef
             }
 
             $found.workflows += $newInfo

--- a/Src/PowerShell/load-used-actions.ps1
+++ b/Src/PowerShell/load-used-actions.ps1
@@ -169,12 +169,12 @@ function SummarizeActionsUsed {
             $newItem =  [PSCustomObject]@{
                 type = $action.type
                 actionLink = $action.actionLink
-                actionRef = $action.actionRef
                 count = 1
                 workflows =  @(
                     [PSCustomObject]@{
                         repo = $action.repo
                         workflowFileName = $action.workflowFileName
+                        actionRef = $action.actionRef
                     }
                 )
             }

--- a/Src/PowerShell/load-used-actions.ps1
+++ b/Src/PowerShell/load-used-actions.ps1
@@ -45,8 +45,9 @@ function  GetActionsFromWorkflow {
                         $uses=$step.Item("uses")
                         if ($null -ne $uses) {
                             Write-Host "   Found action used: [$uses]"
-                            $actionLink = $uses.Split("@")[0]
-                            $actionRef = $uses.Split("@")[1]
+                            $splitted = $uses.Split("@")
+                            $actionLink = $splitted[0]
+                            $actionRef = $splitted[1]
 
                             $data = [PSCustomObject]@{
                                 actionLink = $actionLink

--- a/Src/PowerShell/load-used-actions.ps1
+++ b/Src/PowerShell/load-used-actions.ps1
@@ -65,8 +65,9 @@ function  GetActionsFromWorkflow {
                     $uses = $job.Value.Item("uses")
                     if ($null -ne $uses) {
                         Write-Host "   Found reusable workflow used: [$uses]"
-                        $actionLink = $uses.Split("@")[0]
-                        $actionRef = $uses.Split("@")[1]
+                        $splitted = $uses.Split("@")
+                        $actionLink = $splitted[0]
+                        $actionRef = $splitted[1]
 
                         $data = [PSCustomObject]@{
                             actionLink = $actionLink

--- a/Src/PowerShell/load-used-actions.ps1
+++ b/Src/PowerShell/load-used-actions.ps1
@@ -153,7 +153,7 @@ function SummarizeActionsUsed {
 
     $summarized =  @()
     foreach ($action in $actions) {
-        $found = $summarized | Where-Object { $_.actionLink -eq $action.actionLink -And $_.actionRef -eq $action.actionRef -And $_.type -eq $action.type }
+        $found = $summarized | Where-Object { $_.actionLink -eq $action.actionLink -And $_.type -eq $action.type }
         if ($null -ne $found) {
             # item already found, add this info to it
             $newInfo =  [PSCustomObject]@{

--- a/Src/PowerShell/load-used-actions.ps1
+++ b/Src/PowerShell/load-used-actions.ps1
@@ -46,9 +46,11 @@ function  GetActionsFromWorkflow {
                         if ($null -ne $uses) {
                             Write-Host "   Found action used: [$uses]"
                             $actionLink = $uses.Split("@")[0]
+                            $actionRef = $uses.Split("@")[1]
 
                             $data = [PSCustomObject]@{
                                 actionLink = $actionLink
+                                actionRef = $actionRef
                                 workflowFileName = $workflowFileName
                                 repo = $repo
                                 type = "action"
@@ -64,9 +66,11 @@ function  GetActionsFromWorkflow {
                     if ($null -ne $uses) {
                         Write-Host "   Found reusable workflow used: [$uses]"
                         $actionLink = $uses.Split("@")[0]
+                        $actionRef = $uses.Split("@")[1]
 
                         $data = [PSCustomObject]@{
                             actionLink = $actionLink
+                            actionRef = $actionRef
                             workflowFileName = $workflowFileName
                             repo = $repo
                             type = "reusable workflow"
@@ -147,7 +151,7 @@ function SummarizeActionsUsed {
 
     $summarized =  @()
     foreach ($action in $actions) {
-        $found = $summarized | Where-Object { $_.actionLink -eq $action.actionLink -And $_.type -eq $action.type } 
+        $found = $summarized | Where-Object { $_.actionLink -eq $action.actionLink -And $_.actionRef -eq $action.actionRef -And $_.type -eq $action.type }
         if ($null -ne $found) {
             # item already found, add this info to it
             $newInfo =  [PSCustomObject]@{
@@ -163,6 +167,7 @@ function SummarizeActionsUsed {
             $newItem =  [PSCustomObject]@{
                 type = $action.type
                 actionLink = $action.actionLink
+                actionRef = $action.actionRef
                 count = 1
                 workflows =  @(
                     [PSCustomObject]@{


### PR DESCRIPTION
### What are the incoming changes?
The following changes integrate a new property into the report: `actionRef`

#### Why named action ref? ####
Can be challenged, I thought it's a good idea as after the `@` it can be many different things actually:

`actions@<SHA | tag | version>` < --- Due to that, I think that naming `actionVersion` `actionTag` `actionSha` is not really a good choice.

Let me know if you get a better idea :+1: 

### Why are they needed
https://github.com/devops-actions/load-used-actions/issues/106

### How has this been achieved?
I added the property and tested it on my own workflows it worked like a charm.

It creates one entry per action:ref (= if an action is used with 4 different refs in the GitHub organization, it will be in 4 different "action's" in the report)

This helps to identify which repositories are using actions, including vulnerabilities (i.e version 2 contains an important CVE but 3 fix it)


These are my first line in Powershell, I am very happy to hear your feedback about that change :+1: 

