### PR TITLE
Update publishing.yml

### DIFF
--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -8,7 +8,8 @@ on:
   workflow_dispatch:
     
 # Declare default GITHUB_TOKEN permissions as read only.
-permissions: read-all
+permissions: 
+  contents: read
     
 jobs:
   test-local-action:


### PR DESCRIPTION
Tryin to see if an OSSF Scorecard security alert goes away by having the same setting on the workflow level (it alerts on the job level 'write' permissions.